### PR TITLE
Fix crash in KeyStore due to non-unique key pair alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Our SDK is available on Maven Central.
 
 ```groovy
-implementation 'de.contentpass:contentpass-android:2.2.1'
+implementation 'de.contentpass:contentpass-android:2.2.2'
 ```
 
 Add this to your app's `build.gradle` file's `dependencies` element.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -58,7 +58,7 @@ kapt {
 extra.apply{
     set("PUBLISH_GROUP_ID", "de.contentpass")
     set("PUBLISH_ARTIFACT_ID", "contentpass-android")
-    set("PUBLISH_VERSION", "2.2.1")
+    set("PUBLISH_VERSION", "2.2.2")
 }
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")

--- a/lib/src/main/java/de/contentpass/lib/ContentPass.kt
+++ b/lib/src/main/java/de/contentpass/lib/ContentPass.kt
@@ -112,7 +112,7 @@ class ContentPass internal constructor(
         fun build(): ContentPass {
             configuration = grabConfiguration()
             val authorizer = Authorizer(configuration!!, context!!)
-            val store = TokenStore(context!!, KeyStore(context!!))
+            val store = TokenStore(context!!, KeyStore(context!!, configuration!!.propertyId))
             return ContentPass(authorizer, store, configuration!!)
         }
 

--- a/lib/src/main/java/de/contentpass/lib/KeyStore.kt
+++ b/lib/src/main/java/de/contentpass/lib/KeyStore.kt
@@ -18,9 +18,9 @@ import javax.crypto.spec.SecretKeySpec
 import javax.security.auth.x500.X500Principal
 import java.security.KeyStore as VendorKeyStore
 
-internal class KeyStore(private val context: Context) {
+internal class KeyStore(private val context: Context, private val propertyId: String) {
     private val keystoreName = "AndroidKeyStore"
-    private val keyPairAlias = "de.contentpass.KeyPair"
+    private val keyPairAlias = "de.contentpass.KeyPair.$propertyId"
     private val privateKey: PrivateKey
     private val publicKey: PublicKey
     private val keystore = VendorKeyStore.getInstance(keystoreName)


### PR DESCRIPTION
If a user has installed multiple apps with this SDK, Android will throw an exception when the second app tries to use the same key pair alias. This will crash our SDK and the App. This commit makes sure the key is unique by including the property id in the string.
