### PR TITLE
Use more reliable API to access KeyStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Our SDK is available on Maven Central.
 
 ```groovy
-implementation 'de.contentpass:contentpass-android:2.2.7'
+implementation 'de.contentpass:contentpass-android:2.2.8'
 ```
 
 Add this to your app's `build.gradle` file's `dependencies` element.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -58,7 +58,7 @@ kapt {
 extra.apply{
     set("PUBLISH_GROUP_ID", "de.contentpass")
     set("PUBLISH_ARTIFACT_ID", "contentpass-android")
-    set("PUBLISH_VERSION", "2.2.7")
+    set("PUBLISH_VERSION", "2.2.8")
 }
 
 apply("${rootProject.projectDir}/scripts/publish-module.gradle")


### PR DESCRIPTION
Adopted what https://github.com/adorsys/secure-storage-android is doing in their latest version of  https://github.com/adorsys/secure-storage-android/blob/master/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/KeystoreTool.java 